### PR TITLE
[iOS] General refactor

### DIFF
--- a/iOS/Hekaerge.h
+++ b/iOS/Hekaerge.h
@@ -6,45 +6,34 @@
 //  Copyright © 2016 InnoQuant. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
-#import "MOCAProximityDelegate.h"
-#import <CoreBluetooth/CoreBluetooth.h>
+@import Foundation;
 
-@interface HekaergeLocation : NSObject
+@class Hekaerge;
+@class HekaergeLocation;
 
-@property (readonly) NSString * identifier;
-@property (readonly) CLLocationCoordinate2D center;
-@property (readonly) int floor;
-@property (readonly) double latitude;
-@property (readonly) double longitude;
-@property (readonly) double radius;
-
-
-
--(instancetype)initWithId:(NSString*)identifier
-             withLocation:(CLLocationCoordinate2D)center
-                    floor:(int)floor
-                   radius:(double)radius;
-
--(instancetype)initWithId:(NSString*)identifier
-                 latitude:(double)latitude
-                longitide:(double)longitude
-                    floor:(int)floor
-                   radius:(double)radius;
-@end
 
 @protocol HekaergeDelegate <NSObject>
 
-- (void) didChangeLocation: (NSArray*) locations;
+- (void)hekaerge:(Hekaerge *)hekaerge didChangeLocation:(NSArray<HekaergeLocation *> *)locations;
 
 @end
 
-@interface Hekaerge : NSObject <MOCAProximityEventsDelegate, CBCentralManagerDelegate>
 
-@property id<HekaergeDelegate> delegate;
+@interface Hekaerge : NSObject
 
-- (instancetype)initWithLocations: (NSArray<CLLocation *> *) locations;
-- (NSArray * ) getOrderedLocations;
-- (NSArray *) getDefaultLocations;
+/*
+ * Locations with the default order.
+ */
+@property (strong, nonatomic, readonly) NSArray<HekaergeLocation *> *defaultLocations;
+
+/*
+ * If bluetooth is on, and a beacon (with Location) is in range, the locations list
+ * will be sorted by beacon distance
+ */
+@property (strong, nonatomic, readonly) NSArray<HekaergeLocation *> *orderedLocations;
+
+@property (weak, nonatomic) id<HekaergeDelegate> delegate;
+
+- (instancetype)initWithLocations:(NSArray<HekaergeLocation *> *)locations;
 
 @end

--- a/iOS/HekaergeLocation.h
+++ b/iOS/HekaergeLocation.h
@@ -1,0 +1,32 @@
+//
+//  HekaergeLocation.h
+//  test
+//
+//  Created by Luis Valdés on 31/1/16.
+//  Copyright © 2016 Luis Valdés. All rights reserved.
+//
+
+@import Foundation;
+@import CoreLocation;
+
+@interface HekaergeLocation : NSObject
+
+@property (nonatomic, readonly) NSString * identifier;
+@property (nonatomic, readonly) CLLocationCoordinate2D center;
+@property (nonatomic, readonly) int floor;
+@property (nonatomic, readonly) double latitude;
+@property (nonatomic, readonly) double longitude;
+@property (nonatomic, readonly) double radius;
+
+- (instancetype)initWithId:(NSString *)identifier
+              withLocation:(CLLocationCoordinate2D)center
+                     floor:(int)floor
+                    radius:(double)radius;
+
+- (instancetype)initWithId:(NSString *)identifier
+                  latitude:(double)latitude
+                 longitude:(double)longitude
+                     floor:(int)floor
+                    radius:(double)radius;
+
+@end

--- a/iOS/HekaergeLocation.m
+++ b/iOS/HekaergeLocation.m
@@ -1,0 +1,53 @@
+//
+//  HekaergeLocation.m
+//  test
+//
+//  Created by Luis Valdés on 31/1/16.
+//  Copyright © 2016 Luis Valdés. All rights reserved.
+//
+
+#import "HekaergeLocation.h"
+
+@implementation HekaergeLocation
+
+- (instancetype)initWithId:(NSString *)identifier
+              withLocation:(CLLocationCoordinate2D)center
+                     floor:(int)floor
+                    radius:(double)radius
+{
+    NSParameterAssert(identifier);
+    if (self = [super init]) {
+        _identifier = identifier;
+        _center = center;
+        _floor = floor;
+        _latitude = center.latitude;
+        _longitude = center.longitude;
+        _radius = radius;
+    }
+    return self;
+}
+
+- (instancetype)initWithId:(NSString *)identifier
+                  latitude:(double)latitude
+                 longitude:(double)longitude
+                     floor:(int)floor
+                    radius:(double)radius
+{
+    CLLocationCoordinate2D center;
+    center.latitude = latitude;
+    center.longitude = longitude;
+    return [self initWithId:identifier withLocation:center floor:floor radius:radius];
+}
+
+- (BOOL)isEqualToHekaergeLocation:(HekaergeLocation *)other
+{
+    if (other == self) {
+        return YES;
+    }
+    return (other.latitude   == self.latitude &&
+            other.longitude  == self.latitude &&
+            other.floor      == self.floor &&
+            other.radius     == self.radius);
+}
+
+@end


### PR DESCRIPTION
Remove `#import`s from `.h` files. Use Forward Class Declaration.
Remove `@synthesize`. No longer necessary for default cases.
Replace ivars with private properties, and access ivars only in initializer. Use properties elsewhere.
Replace getter methods with `readonly` properties.
Hide implementation details by moving `Hekaerge`'s protocol declaration to `.m` file (`MOCAProximityEventsDelegate` and `CBCentralManagerDelegate`).
Add missing type declaration to `NSArray`s.
General refactor.
Revisit language style.
Extract `HekaergeLocation` to its own file.
Fix typo in `HekaergeLocation` initializer's name.

Note: no testing was performed due to lack of availability of `MOCA`-related classes.
